### PR TITLE
fix: update MhLabs packages

### DIFF
--- a/MhLabs.APIGatewayLambdaProxy/LambdaEntryPointBase.cs
+++ b/MhLabs.APIGatewayLambdaProxy/LambdaEntryPointBase.cs
@@ -129,7 +129,7 @@ namespace MhLabs.APIGatewayLambdaProxy
             _httpClient = _httpClient ?? new HttpClient(new AwsSignedHttpMessageHandler { InnerHandler = new HttpClientHandler() }) { BaseAddress = Env.Get("ApiBaseUrl").ToUri() };
         }
 
-        [LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+        [LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
         public async Task PreTrafficHook(CodeDeployEvent deployment)
         {
             var status = LifecycleEventStatus.Succeeded;
@@ -187,7 +187,7 @@ namespace MhLabs.APIGatewayLambdaProxy
             await _codeDeploy.PutLifecycleEventHookExecutionStatusAsync(request);
         }
 
-        [LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+        [LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
         public async Task PostTrafficHook(CodeDeployEvent deployment)
         {
             var status = LifecycleEventStatus.Succeeded;

--- a/MhLabs.APIGatewayLambdaProxy/MhLabs.APIGatewayLambdaProxy.csproj
+++ b/MhLabs.APIGatewayLambdaProxy/MhLabs.APIGatewayLambdaProxy.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Version>5.0.1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
@@ -11,8 +11,8 @@
     <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="6.0.3" />
     <PackageReference Include="AWSSDK.CodeDeploy" Version="3.7.0.82" />
     <PackageReference Include="awssdk.lambda" Version="3.7.4.9" />
-    <PackageReference Include="MhLabs.AwsSignedHttpClient" Version="8.0.0" />
-    <PackageReference Include="MhLabs.Extensions" Version="1.0.10" />
+    <PackageReference Include="MhLabs.AwsSignedHttpClient" Version="8.1.1" />
+    <PackageReference Include="MhLabs.Extensions" Version="1.0.11" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Updated the package MhLabs.AwsSignedHttpClient due to a bug where errors were swallowed. The PR also includes performance improvements since the JSON serializers were updated as well.

BREAKING CHANGE: Changed the target framework to netcoreapp3.1 since the MhLabs.AwsSignedHttpClient package version 8.1.1 depends on it.

Pull fixing the bug: https://github.com/mhlabs/MhLabs.AwsSignedHttpClient/pull/10